### PR TITLE
Leaner dist packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+.github export-ignore
+docker export-ignore
+tests export-ignore
+.gitignore export-ignore
+.gitattributes export-ignore
+Makefile export-ignore
+phpunit.xml export-ignore


### PR DESCRIPTION
When a dependee project installs the library as a dependency with the `--prefer-dist` flag (default) there's no need to ship the dev files/folders, as they are not supposed to be used by the client code.
