### PR TITLE
Replace native mixed typehint with a docblock tag

### DIFF
--- a/src/CheckboxJsonApi.php
+++ b/src/CheckboxJsonApi.php
@@ -245,7 +245,10 @@ class CheckboxJsonApi
         return (new ShiftMapper())->jsonToObject($jsonResponse);
     }
 
-    public function pingTaxServiceAction(): mixed
+    /**
+     * @return mixed
+     */
+    public function pingTaxServiceAction()
     {
         $response = $this->sendRequest(
             self::METHOD_POST,


### PR DESCRIPTION
`mixed` is not available on PHP 7.4, yet the library declares PHP 7.4 compatibility
