### PR TITLE
Fix typo (`sign` vs `sing`)

### DIFF
--- a/src/CheckboxJsonApi.php
+++ b/src/CheckboxJsonApi.php
@@ -139,7 +139,7 @@ class CheckboxJsonApi
 
         $response = $this->sendRequest(
             self::METHOD_POST,
-            $this->routes->singInCashier(),
+            $this->routes->signInCashier(),
             $options
         );
 
@@ -158,7 +158,7 @@ class CheckboxJsonApi
     {
         $response = $this->sendRequest(
             self::METHOD_POST,
-            $this->routes->singOutCashier(),
+            $this->routes->signOutCashier(),
             $this->requestOptions
         );
 

--- a/src/Routes.php
+++ b/src/Routes.php
@@ -19,12 +19,24 @@ class Routes
         $this->apiUrl = $appUrl;
     }
 
+    /** @deprecated */
     public function singInCashier(): string
+    {
+        return $this->signInCashier();
+    }
+
+    public function signInCashier(): string
     {
         return $this->apiUrl . '/cashier/signin';
     }
 
+    /** @deprecated */
     public function singOutCashier(): string
+    {
+        return $this->signOutCashier();
+    }
+
+    public function signOutCashier(): string
     {
         return $this->apiUrl . '/cashier/signout';
     }

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -20,7 +20,7 @@ class RoutesTest extends TestCase
     {
         $this->assertStringContainsString(
             "signin",
-            (new Routes(""))->singInCashier()
+            (new Routes(""))->signInCashier()
         );
     }
 
@@ -28,7 +28,7 @@ class RoutesTest extends TestCase
     {
         $this->assertStringContainsString(
             "signout",
-            (new Routes(""))->singOutCashier()
+            (new Routes(""))->signOutCashier()
         );
     }
     public function testSignInCashierViaSignature(): void


### PR DESCRIPTION
Correct names are `signIn`/`signOut` rather than `singIn`/`singOut`.

Old method names are kept and marked `@deprecated` to maintain backward
compatibility.
