### PR TITLE
Introduce common exception interface

### DIFF
--- a/src/Errors/AlreadyOpenedShift.php
+++ b/src/Errors/AlreadyOpenedShift.php
@@ -2,6 +2,6 @@
 
 namespace igorbunov\Checkbox\Errors;
 
-class AlreadyOpenedShift extends \Exception
+class AlreadyOpenedShift extends \Exception implements Exception
 {
 }

--- a/src/Errors/EmptyResponse.php
+++ b/src/Errors/EmptyResponse.php
@@ -2,6 +2,6 @@
 
 namespace igorbunov\Checkbox\Errors;
 
-class EmptyResponse extends \Exception
+class EmptyResponse extends \Exception implements Exception
 {
 }

--- a/src/Errors/Exception.php
+++ b/src/Errors/Exception.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace igorbunov\Checkbox\Errors;
+
+use Throwable;
+
+interface Exception extends Throwable
+{
+}

--- a/src/Errors/InvalidCredentials.php
+++ b/src/Errors/InvalidCredentials.php
@@ -2,6 +2,6 @@
 
 namespace igorbunov\Checkbox\Errors;
 
-class InvalidCredentials extends \Exception
+class InvalidCredentials extends \Exception implements Exception
 {
 }

--- a/src/Errors/NoActiveShift.php
+++ b/src/Errors/NoActiveShift.php
@@ -2,6 +2,6 @@
 
 namespace igorbunov\Checkbox\Errors;
 
-class NoActiveShift extends \Exception
+class NoActiveShift extends \Exception implements Exception
 {
 }

--- a/src/Errors/Validation.php
+++ b/src/Errors/Validation.php
@@ -2,7 +2,7 @@
 
 namespace igorbunov\Checkbox\Errors;
 
-class Validation extends \Exception
+class Validation extends \Exception implements Exception
 {
     /** @var array<mixed> $detail */
     protected $detail;


### PR DESCRIPTION
This would allow clients to capture all exceptions originating from the
library code with a single catch, should they need to.

E.g. they would be able to use:

```php
	use igorbunov\Checkbox\Errors\Exception as CheckboxException;
	// ...
	try {
		$checboxApi->method();
	} catch (CheckboxException $e) {
		$this->logger->error('Checkbox API call failed');
		throw new ExternalIntegrationError($e);
	}
```

instead of

```php
	try {
		$checboxApi->method();
	} catch (AlreadyOpenedShift $e) {
		$this->logger->error('Checkbox API call failed');
		throw new ExternalIntegrationError($e);
	} catch (EmptyResponse $e) {
		$this->logger->error('Checkbox API call failed');
		throw new ExternalIntegrationError($e);
	}
	// ... and so on
```
