### PR TITLE
Розширення класу CardPaymentPayload

### DIFF
--- a/src/Mappers/Receipts/Payments/CardPaymentMapper.php
+++ b/src/Mappers/Receipts/Payments/CardPaymentMapper.php
@@ -21,7 +21,15 @@ class CardPaymentMapper
             $json['value'],
             $json['label'] ?? '',
             $json['code'] ?? 0,
-            $json['card_mask'] ?? '0000 0000 0000 0000'
+            $json['card_mask'] ?? '0000 0000 0000 0000',
+            $json['terminal'] ?? '',
+            $json['rrn'] ?? '',
+            $json['card_name'] ?? '',
+            $json['auth_code'] ?? '',
+            $json['payment_system'] ?? '',
+            $json['receipt_no'] ?? '',
+            $json['acquirer_and_seller'] ?? '',
+            $json['commission'] ?? 0,
         );
 
         return $receipt;
@@ -48,6 +56,38 @@ class CardPaymentMapper
 
         if (!empty($obj->card_mask)) {
             $result['card_mask'] = $obj->card_mask;
+        }
+
+        if (!empty($obj->bank_name)) {
+            $result['bank_name'] = $obj->bank_name;
+        }
+
+        if (!empty($obj->auth_code)) {
+            $result['auth_code'] = $obj->auth_code;
+        }
+
+        if (!empty($obj->rrn)) {
+            $result['rrn'] = $obj->rrn;
+        }
+
+        if (!empty($obj->payment_system)) {
+            $result['payment_system'] = $obj->payment_system;
+        }
+
+        if (!empty($obj->terminal)) {
+            $result['terminal'] = $obj->terminal;
+        }
+
+        if (!empty($obj->acquirer_and_seller)) {
+            $result['acquirer_and_seller'] = $obj->acquirer_and_seller;
+        }
+
+        if (!empty($obj->receipt_no)) {
+            $result['receipt_no'] = $obj->receipt_no;
+        }
+
+        if (!empty($obj->commision)) {
+            $result['commission'] = $obj->commision;
         }
 
         return $result;

--- a/src/Mappers/Receipts/Payments/PaymentsMapper.php
+++ b/src/Mappers/Receipts/Payments/PaymentsMapper.php
@@ -2,13 +2,11 @@
 
 namespace igorbunov\Checkbox\Mappers\Receipts\Payments;
 
+use igorbunov\Checkbox\Models\Receipts\Payments\PaymentParent;
 use igorbunov\Checkbox\Models\Receipts\Payments\Payments;
 
 class PaymentsMapper
 {
-    public const TYPE_CASH = 'CASH';
-    public const TYPE_CARD = 'CARD';
-
     /**
      * @param mixed $json
      * @return Payments|null
@@ -22,13 +20,13 @@ class PaymentsMapper
         $results = [];
 
         foreach ($json as $payment) {
-            if ($payment['type'] == self::TYPE_CASH) {
+            if ($payment['type'] == PaymentParent::TYPE_CASH) {
                 $pay = (new CashPaymentMapper())->jsonToObject($payment);
 
                 if (!is_null($pay)) {
                     $results[] = $pay;
                 }
-            } elseif ($payment['type'] == self::TYPE_CARD) {
+            } elseif ($payment['type'] == PaymentParent::TYPE_CARD) {
                 $pay = (new CardPaymentMapper())->jsonToObject($payment);
 
                 if (!is_null($pay)) {
@@ -51,9 +49,9 @@ class PaymentsMapper
         $results = [];
 
         foreach ($payments->results as $payment) {
-            if ($payment->type == self::TYPE_CASH) {
+            if ($payment->type == PaymentParent::TYPE_CASH) {
                 $results[] = (new CashPaymentMapper())->objectToJson($payment);
-            } elseif ($payment->type == self::TYPE_CARD) {
+            } elseif ($payment->type == PaymentParent::TYPE_CARD) {
                 $results[] = (new CardPaymentMapper())->objectToJson($payment);
             }
         }

--- a/src/Models/Receipts/Payments/CardPaymentPayload.php
+++ b/src/Models/Receipts/Payments/CardPaymentPayload.php
@@ -9,15 +9,40 @@ class CardPaymentPayload extends PaymentParent
     /** @var string $card_mask */
     public $card_mask;
 
+    public string $terminal;
+    public string $rrn;
+    public string $card_name;
+    public string $auth_code;
+    public string $payment_system;
+    public string $receipt_no;
+    public string $acquirer_and_seller;
+    public int $commission;
+
     public function __construct(
         string $value,
         string $label = 'Безготівковий',
         int $code = 0,
-        string $card_mask = ''
+        string $card_mask = '',
+        string $card_name = '',
+        string $terminal = '',
+        string $rrn = '',
+        string $auth_code = '',
+        string $payment_system = '',
+        string $receipt_no = '',
+        string $acquirer_and_seller = '',
+        int $commission = 0
     ) {
         parent::__construct(parent::TYPE_CARD, $value, $label);
 
         $this->code = $code;
         $this->card_mask = $card_mask;
+        $this->card_name = $card_name;
+        $this->terminal = $terminal;
+        $this->rrn = $rrn;
+        $this->auth_code = $auth_code;
+        $this->payment_system = $payment_system;
+        $this->receipt_no = $receipt_no;
+        $this->acquirer_and_seller = $acquirer_and_seller;
+        $this->commission = $commission;
     }
 }

--- a/src/Models/Receipts/Payments/PaymentParent.php
+++ b/src/Models/Receipts/Payments/PaymentParent.php
@@ -5,7 +5,7 @@ namespace igorbunov\Checkbox\Models\Receipts\Payments;
 class PaymentParent
 {
     public const TYPE_CASH = 'CASH';
-    public const TYPE_CARD = 'CARD';
+    public const TYPE_CARD = 'CASHLESS';
 
     /** @var string $type */
     public $type;

--- a/tests/Mappers/SellReceiptTest.php
+++ b/tests/Mappers/SellReceiptTest.php
@@ -35,7 +35,7 @@ class SellReceiptTest extends TestCase
             '"discounts":[]},{"good":{"code":"vm-124","name":"\u0411\u0438\u043e\u0432\u0430\u043a 2",' .
             '"barcode":"","header":"","footer":"","price":2000,"tax":["123123"],"uktzed":""},' .
             '"quantity":2000,"is_return":false,"discounts":[]}],"delivery":{"email":"admin@gmail.com"},' .
-            '"discounts":[],"payments":[{"type":"CARD","value":"4000","la' .
+            '"discounts":[],"payments":[{"type":"CASHLESS","value":"4000","la' .
             'bel":"\u0411\u0435\u0437\u0433\u043e\u0442\u0456\u0432\u043a\u043e\u0432\u0438\u0439"},{"ty' .
             'pe":"CASH","value":"5000","label":"\u0413\u043e\u0442\u0456\u0432\u043a\u043e\u044e"}],"head' .
             'er":"","footer":"","barcode":""}';
@@ -103,7 +103,7 @@ class SellReceiptTest extends TestCase
            ],
            "payments":[
               {
-                 "type":"CARD",
+                 "type":"CASHLESS",
                  "code":null,
                  "value":"4000",
                  "label":"Безготівковий",


### PR DESCRIPTION
Розширення класу CardPaymentPayload у відповідність з моделю checkbox API  для передачі обов'язкових даних ЕПЗ, після оплати картою через пос-термінал
